### PR TITLE
Add `v4rc1` context with `image`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @digitalbazaar/citizenship-context ChangeLog
 
+## 4.1.0 - 2024-10-xx
+
+### Added
+- Add `image` to `v4rc1` context. It was removed from `v1` but is still needed
+  in updated examples so that issuers can have images without requiring an extra context.
+
 ## 4.0.0 - 2024-09-12
 
 ### Added

--- a/contexts/v4rc1.jsonld
+++ b/contexts/v4rc1.jsonld
@@ -1,0 +1,223 @@
+{
+  "@context": {
+    "@protected": true,
+    "image": {
+      "@id": "https://schema.org/image",
+      "@type": "@id"
+    },
+    "QuantitativeValue": {
+      "@id": "https://schema.org/QuantitativeValue",
+      "@context": {
+        "@protected": true,
+        "unitCode": "https://schema.org/unitCode",
+        "value": "https://schema.org/value"
+      }
+    },
+    "PostalAddress": {
+      "@id": "https://schema.org/PostalAddress",
+      "@context": {
+        "@protected": true,
+        "addressCountry": "https://schema.org/addressCountry",
+        "addressLocality": "https://schema.org/addressLocality",
+        "addressRegion": "https://schema.org/addressRegion"
+      }
+    },
+    "Person": {
+      "@id": "https://schema.org/Person",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "additionalName": "https://schema.org/additionalName",
+        "birthCountry": "https://w3id.org/citizenship#birthCountry",
+        "birthDate": {
+          "@id": "https://schema.org/birthDate",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "familyName": "https://schema.org/familyName",
+        "gender": "https://schema.org/gender",
+        "givenName": "https://schema.org/givenName",
+        "height": "https://schema.org/height",
+        "image": {
+          "@id": "https://schema.org/image",
+          "@type": "@id"
+        },
+        "maritalStatus": "https://w3id.org/citizenship#maritalStatus",
+        "marriageCertificateNumber": "https://w3id.org/citizenship#marriageCertificateNumber",
+        "marriageLocation": {
+          "@id": "https://w3id.org/citizenship#marriageLocation",
+          "@type": "@id"
+        }
+      }
+    },
+    "PermanentResident": {
+      "@id": "https://w3id.org/citizenship#PermanentResident",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "commuterClassification": "https://w3id.org/citizenship#commuterClassification",
+        "formerNationality": "https://w3id.org/citizenship#formerNationality",
+        "permanentResidentCard": {
+          "@id": "https://w3id.org/citizenship#permanentResidentCard",
+          "@type": "@id"
+        },
+        "residence": {
+          "@id": "https://w3id.org/citizenship#residence",
+          "@type": "@id"
+        },
+        "residentSince": {
+          "@id": "https://w3id.org/citizenship#residentSince",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        }
+      }
+    },
+    "PermanentResidentCard": {
+      "@id": "https://w3id.org/citizenship#PermanentResidentCard",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "filingLocation": {
+          "@id": "https://w3id.org/citizenship#filingLocation",
+          "@type": "@id"
+        },
+        "identifier": "https://schema.org/identifier",
+        "lprCategory": "https://w3id.org/citizenship#lprCategory",
+        "lprNumber": "https://w3id.org/citizenship#lprNumber",
+        "mrzHash": {
+          "@id": "https://w3id.org/citizenship#mrzHash",
+          "@type": "https://w3id.org/security#multibase"
+        }
+      }
+    },
+    "PermanentResidentCardCredential": "https://w3id.org/citizenship#PermanentResidentCardCredential",
+    "EmployablePerson": {
+      "@id": "https://w3id.org/citizenship#EmployablePerson",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "commuterClassification": "https://w3id.org/citizenship#commuterClassification",
+        "employmentAuthorizationDocument": {
+          "@id": "https://w3id.org/citizenship#employmentAuthorizationDocument",
+          "@type": "@id"
+        },
+        "formerNationality": "https://w3id.org/citizenship#formerNationality",
+        "residence": {
+          "@id": "https://w3id.org/citizenship#residence",
+          "@type": "@id"
+        },
+        "residentSince": {
+          "@id": "https://w3id.org/citizenship#residentSince",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        }
+      }
+    },
+    "EmploymentAuthorizationDocument": {
+      "@id": "https://w3id.org/citizenship#EmploymentAuthorizationDocument",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "filingLocation": {
+          "@id": "https://w3id.org/citizenship#filingLocation",
+          "@type": "@id"
+        },
+        "identifier": "https://schema.org/identifier",
+        "lprCategory": "https://w3id.org/citizenship#lprCategory",
+        "lprNumber": "https://w3id.org/citizenship#lprNumber",
+        "mrzHash": {
+          "@id": "https://w3id.org/citizenship#mrzHash",
+          "@type": "https://w3id.org/security#multibase"
+        }
+      }
+    },
+    "EmploymentAuthorizationDocumentCredential": "https://w3id.org/citizenship#EmploymentAuthorizationDocumentCredential",
+    "NaturalizedPerson": {
+      "@id": "https://w3id.org/citizenship#NaturalizedPerson",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "formerNationality": "https://w3id.org/citizenship#formerNationality",
+        "certificateOfNaturalization": {
+          "@id": "https://w3id.org/citizenship#certificateOfNaturalization",
+          "@type": "@id"
+        },
+        "residence": {
+          "@id": "https://w3id.org/citizenship#residence",
+          "@type": "@id"
+        },
+        "residentSince": {
+          "@id": "https://w3id.org/citizenship#residentSince",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "commuterClassification": "https://w3id.org/citizenship#commuterClassification"
+      }
+    },
+    "CertificateOfNaturalization": {
+      "@id": "https://w3id.org/citizenship#CertificateOfNaturalization",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "ceremonyDate": {
+          "@id": "https://w3id.org/citizenship#ceremonyDate",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "ceremonyLocation": {
+          "@id": "https://w3id.org/citizenship#ceremonyLocation",
+          "@type": "@id"
+        },
+        "filingLocation": {
+          "@id": "https://w3id.org/citizenship#filingLocation",
+          "@type": "@id"
+        },
+        "naturalizationLocation": {
+          "@id": "https://w3id.org/citizenship#naturalizationLocation",
+          "@type": "@id"
+        },
+        "naturalizedBy": "https://w3id.org/citizenship#naturalizedBy",
+        "identifier": "https://schema.org/identifier",
+        "insRegistrationNumber": "https://w3id.org/citizenship#insRegistrationNumber"
+      }
+    },
+    "CertificateOfNaturalizationCredential": "https://w3id.org/citizenship#CertificateOfNaturalizationCredential",
+    "Citizen": {
+      "@id": "https://w3id.org/citizenship#Citizen",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "certificateOfCitizenship": {
+          "@id": "https://w3id.org/citizenship#certificateOfCitizenship",
+          "@type": "@id"
+        }
+      }
+    },
+    "CertificateOfCitizenship": {
+      "@id": "https://w3id.org/citizenship#CertificateOfCitizenship",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "filingLocation": {
+          "@id": "https://w3id.org/citizenship#filingLocation",
+          "@type": "@id"
+        },
+        "identifier": "https://schema.org/identifier",
+        "ceremonyDate": {
+          "@id": "https://w3id.org/citizenship#ceremonyDate",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "ceremonyLocation": {
+          "@id": "https://w3id.org/citizenship#ceremonyLocation",
+          "@type": "@id"
+        },
+        "cisRegistrationNumber": "https://w3id.org/citizenship#cisRegistrationNumber"
+      }
+    },
+    "CertificateOfCitizenshipCredential": "https://w3id.org/citizenship#CertificateOfCitizenshipCredential"
+  }
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@
 import v1Context from './v1.js';
 import v2Context from './v2.js';
 import v3Context from './v3.js';
+import v4rc1Context from './v4rc1.js';
 
 // map of context id to context
 export const contexts = new Map();
@@ -48,5 +49,15 @@ setExportsFromMetadata({
     shortName: 'v3',
     fileUrl: new URL('../contexts/v3.jsonld', import.meta.url),
     context: v3Context
+  }
+});
+setExportsFromMetadata({
+  contextsMap: contexts, metadataMap: metadata, namedMap: named,
+  metadata: {
+    id: 'https://w3id.org/citizenship/v4rc1',
+    type: 'ContextMetadata',
+    shortName: 'v4rc1',
+    fileUrl: new URL('../contexts/v4rc1.jsonld', import.meta.url),
+    context: v4rc1Context
   }
 });

--- a/lib/v4rc1.js
+++ b/lib/v4rc1.js
@@ -1,0 +1,203 @@
+/*!
+ * Copyright (c) 2024 Digital Bazaar, Inc. All rights reserved.
+ */
+// Use JSON style for context
+/* eslint quotes: ['error', 'double'] */
+/* eslint quote-props: ['error', 'always'] */
+/* eslint-disable max-len */
+
+export default
+/* context-url: https://w3id.org/citizenship/v4rc1 */
+/* context-begin */
+{
+  "@context": {
+    "@protected": true,
+
+    "image": {"@id": "https://schema.org/image", "@type": "@id"},
+
+    "QuantitativeValue": {
+      "@id": "https://schema.org/QuantitativeValue",
+      "@context": {
+        "@protected": true,
+
+        "unitCode": "https://schema.org/unitCode",
+        "value": "https://schema.org/value"
+      }
+    },
+
+    "PostalAddress": {
+      "@id": "https://schema.org/PostalAddress",
+      "@context": {
+        "@protected": true,
+
+        "addressCountry": "https://schema.org/addressCountry",
+        "addressLocality": "https://schema.org/addressLocality",
+        "addressRegion": "https://schema.org/addressRegion"
+      }
+    },
+
+    "Person": {
+      "@id": "https://schema.org/Person",
+
+      "@context": {
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "additionalName": "https://schema.org/additionalName",
+        "birthCountry": "https://w3id.org/citizenship#birthCountry",
+        "birthDate": {"@id": "https://schema.org/birthDate", "@type": "http://www.w3.org/2001/XMLSchema#dateTime"},
+        "familyName": "https://schema.org/familyName",
+        "gender": "https://schema.org/gender",
+        "givenName": "https://schema.org/givenName",
+        "height": "https://schema.org/height",
+        "image": {"@id": "https://schema.org/image", "@type": "@id"},
+        "maritalStatus": "https://w3id.org/citizenship#maritalStatus",
+        "marriageCertificateNumber": "https://w3id.org/citizenship#marriageCertificateNumber",
+        "marriageLocation": {"@id": "https://w3id.org/citizenship#marriageLocation", "@type": "@id"}
+      }
+    },
+
+    "PermanentResident": {
+      "@id": "https://w3id.org/citizenship#PermanentResident",
+      "@context": {
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "commuterClassification": "https://w3id.org/citizenship#commuterClassification",
+        "formerNationality": "https://w3id.org/citizenship#formerNationality",
+        "permanentResidentCard": {"@id": "https://w3id.org/citizenship#permanentResidentCard", "@type": "@id"},
+        "residence": {"@id": "https://w3id.org/citizenship#residence", "@type": "@id"},
+        "residentSince": {"@id": "https://w3id.org/citizenship#residentSince", "@type": "http://www.w3.org/2001/XMLSchema#dateTime"}
+      }
+    },
+
+    "PermanentResidentCard": {
+      "@id": "https://w3id.org/citizenship#PermanentResidentCard",
+      "@context": {
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "filingLocation": {"@id": "https://w3id.org/citizenship#filingLocation", "@type": "@id"},
+        "identifier": "https://schema.org/identifier",
+        "lprCategory": "https://w3id.org/citizenship#lprCategory",
+        "lprNumber": "https://w3id.org/citizenship#lprNumber",
+        "mrzHash": {
+          "@id": "https://w3id.org/citizenship#mrzHash",
+          "@type": "https://w3id.org/security#multibase"
+        }
+      }
+    },
+
+    "PermanentResidentCardCredential": "https://w3id.org/citizenship#PermanentResidentCardCredential",
+
+    "EmployablePerson": {
+      "@id": "https://w3id.org/citizenship#EmployablePerson",
+      "@context": {
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "commuterClassification": "https://w3id.org/citizenship#commuterClassification",
+        "employmentAuthorizationDocument": {"@id": "https://w3id.org/citizenship#employmentAuthorizationDocument", "@type": "@id"},
+        "formerNationality": "https://w3id.org/citizenship#formerNationality",
+        "residence": {"@id": "https://w3id.org/citizenship#residence", "@type": "@id"},
+        "residentSince": {"@id": "https://w3id.org/citizenship#residentSince", "@type": "http://www.w3.org/2001/XMLSchema#dateTime"}
+      }
+    },
+
+    "EmploymentAuthorizationDocument": {
+      "@id": "https://w3id.org/citizenship#EmploymentAuthorizationDocument",
+      "@context": {
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "filingLocation": {"@id": "https://w3id.org/citizenship#filingLocation", "@type": "@id"},
+        "identifier": "https://schema.org/identifier",
+        "lprCategory": "https://w3id.org/citizenship#lprCategory",
+        "lprNumber": "https://w3id.org/citizenship#lprNumber",
+        "mrzHash": {
+          "@id": "https://w3id.org/citizenship#mrzHash",
+          "@type": "https://w3id.org/security#multibase"
+        }
+      }
+    },
+
+    "EmploymentAuthorizationDocumentCredential": "https://w3id.org/citizenship#EmploymentAuthorizationDocumentCredential",
+
+    "NaturalizedPerson": {
+      "@id": "https://w3id.org/citizenship#NaturalizedPerson",
+      "@context": {
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "formerNationality": "https://w3id.org/citizenship#formerNationality",
+        "certificateOfNaturalization": {"@id": "https://w3id.org/citizenship#certificateOfNaturalization", "@type": "@id"},
+        "residence": {"@id": "https://w3id.org/citizenship#residence", "@type": "@id"},
+        "residentSince": {"@id": "https://w3id.org/citizenship#residentSince", "@type": "http://www.w3.org/2001/XMLSchema#dateTime"},
+        "commuterClassification": "https://w3id.org/citizenship#commuterClassification"
+      }
+    },
+
+    "CertificateOfNaturalization": {
+      "@id": "https://w3id.org/citizenship#CertificateOfNaturalization",
+      "@context": {
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "ceremonyDate": {"@id": "https://w3id.org/citizenship#ceremonyDate", "@type": "http://www.w3.org/2001/XMLSchema#dateTime"},
+        "ceremonyLocation": {"@id": "https://w3id.org/citizenship#ceremonyLocation", "@type": "@id"},
+        "filingLocation": {"@id": "https://w3id.org/citizenship#filingLocation", "@type": "@id"},
+        "naturalizationLocation": {"@id": "https://w3id.org/citizenship#naturalizationLocation", "@type": "@id"},
+        "naturalizedBy": "https://w3id.org/citizenship#naturalizedBy",
+        "identifier": "https://schema.org/identifier",
+        "insRegistrationNumber": "https://w3id.org/citizenship#insRegistrationNumber"
+      }
+    },
+
+    "CertificateOfNaturalizationCredential": "https://w3id.org/citizenship#CertificateOfNaturalizationCredential",
+
+    "Citizen": {
+      "@id": "https://w3id.org/citizenship#Citizen",
+      "@context": {
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "certificateOfCitizenship": {"@id": "https://w3id.org/citizenship#certificateOfCitizenship", "@type": "@id"}
+      }
+    },
+
+    "CertificateOfCitizenship": {
+      "@id": "https://w3id.org/citizenship#CertificateOfCitizenship",
+      "@context": {
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "filingLocation": {"@id": "https://w3id.org/citizenship#filingLocation", "@type": "@id"},
+        "identifier": "https://schema.org/identifier",
+        "ceremonyDate": {"@id": "https://w3id.org/citizenship#ceremonyDate", "@type": "http://www.w3.org/2001/XMLSchema#dateTime"},
+        "ceremonyLocation": {"@id": "https://w3id.org/citizenship#ceremonyLocation", "@type": "@id"},
+        "cisRegistrationNumber": "https://w3id.org/citizenship#cisRegistrationNumber"
+      }
+    },
+
+    "CertificateOfCitizenshipCredential": "https://w3id.org/citizenship#CertificateOfCitizenshipCredential"
+  }
+}
+/* context-end */;

--- a/test/context.common.cjs
+++ b/test/context.common.cjs
@@ -4,17 +4,17 @@
 module.exports.tests = function({contexts, metadata, named, expect}) {
   it('contexts', async () => {
     expect(metadata).to.exist;
-    expect(metadata.size).to.equal(3);
+    expect(metadata.size).to.equal(4);
   });
 
   it('metadata', async () => {
     expect(metadata).to.exist;
-    expect(metadata.size).to.equal(3);
+    expect(metadata.size).to.equal(4);
   });
 
   it('named', async () => {
     expect(named).to.exist;
-    expect(named.size).to.equal(3);
+    expect(named.size).to.equal(4);
   });
 
   it('contents', async () => {
@@ -30,6 +30,10 @@ module.exports.tests = function({contexts, metadata, named, expect}) {
       {
         id: 'https://w3id.org/citizenship/v3',
         name: 'v3'
+      },
+      {
+        id: 'https://w3id.org/citizenship/v4rc1',
+        name: 'v4rc1'
       }
     ];
 


### PR DESCRIPTION
Added
- Add `image` to `v4rc1` context. It was removed from `v1` but is still needed in updated examples so that issuers can have images without requiring an extra context.